### PR TITLE
Update to IBM sarama

### DIFF
--- a/partitioner.go
+++ b/partitioner.go
@@ -3,7 +3,7 @@ package kafkautil
 import (
 	"hash"
 
-	"github.com/Shopify/sarama"
+	"github.com/IBM/sarama"
 )
 
 // NewJVMCompatiblePartitioner creates a Sarama partitioner that uses


### PR DESCRIPTION
quick fix to use latest sarama library, now maintained by IBM.